### PR TITLE
v1.0.20 - Feature: add Virtual List view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.20
+
+- `HTMLOptionsCollection`, `TouchList`, `FileList`, `CSSRuleList`,
+  `DOMTokenList`, `NamedNodeMap`, `HTMLCollection`, `NodeList` extensions:
+  - Added `asListView` getter returning a `VirtualListView` for lazy indexed access.
+  - Added `asListViewFixed` getter returning a `VirtualFixedListView` with fixed length.
+
+- `pubspec.yaml`:
+  - Updated `test` dependency from `^1.28.0` to `^1.29.0`.
+
 ## 1.0.19
 
 - `NamedNodeMapExtension`:

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+APIKEY=$1
+shift  # remove the first argument (API key) from "$@"
+
+## dart pub global activate dart_bump
+
+dart_bump . \
+  --api-key $APIKEY \
+  "$@"

--- a/lib/src/web_utils_extensions.dart
+++ b/lib/src/web_utils_extensions.dart
@@ -6,6 +6,7 @@ import 'package:web/web.dart' as web;
 import 'package:web/web.dart' hide querySelector;
 
 import 'web_utils_type_checks.dart';
+import 'wev_utils_virtual_list.dart';
 
 extension WebObjectExtension on Object? {
   bool get isNode => asJSAny.isNode;
@@ -752,6 +753,12 @@ extension HTMLOptionsCollectionExtension on HTMLOptionsCollection {
   List<HTMLOptionElement> toList() =>
       List.generate(length, (i) => item(i) as HTMLOptionElement);
 
+  VirtualListView<HTMLOptionElement> get asListView =>
+      VirtualListView(() => length, (i) => item(i) as HTMLOptionElement);
+
+  VirtualFixedListView<HTMLOptionElement> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i) as HTMLOptionElement);
+
   bool get isEmpty => length == 0;
 
   bool get isNotEmpty => !isEmpty;
@@ -762,6 +769,12 @@ extension TouchListExtension on TouchList {
 
   List<Touch> toList() => List.generate(length, (i) => item(i)!);
 
+  VirtualListView<Touch> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<Touch> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
+
   bool get isEmpty => length == 0;
 
   bool get isNotEmpty => !isEmpty;
@@ -771,6 +784,12 @@ extension FileListExtension on FileList {
   Iterable<File> toIterable() => Iterable.generate(length, (i) => item(i)!);
 
   List<File> toList() => List.generate(length, (i) => item(i)!);
+
+  VirtualListView<File> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<File> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
 
   bool get isEmpty => length == 0;
 
@@ -787,6 +806,12 @@ extension CSSRuleListExtension on CSSRuleList {
   Iterable<CSSRule> toIterable() => Iterable.generate(length, (i) => item(i)!);
 
   List<CSSRule> toList() => List.generate(length, (i) => item(i)!);
+
+  VirtualListView<CSSRule> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<CSSRule> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
 
   bool get isEmpty => length == 0;
 
@@ -808,6 +833,12 @@ extension DOMTokenListExtension on DOMTokenList {
       Iterable.generate(length, (i) => item(i)!.toDartFix);
 
   List<String> toList() => List.generate(length, (i) => item(i)!.toDartFix);
+
+  VirtualListView<String> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!.toDartFix);
+
+  VirtualFixedListView<String> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!.toDartFix);
 
   bool get isEmpty => length == 0;
 
@@ -847,6 +878,12 @@ extension NamedNodeMapExtension on NamedNodeMap {
 
   List<Attr> toList() => List.generate(length, (i) => item(i)!);
 
+  VirtualListView<Attr> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<Attr> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
+
   Iterable<T> whereType<T>() => toIterable().whereType<T>();
 
   bool get isEmpty => length == 0;
@@ -880,6 +917,12 @@ extension HTMLCollectionExtension on HTMLCollection {
 
   List<Element> toList() => List.generate(length, (i) => item(i)!);
 
+  VirtualListView<Element> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<Element> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
+
   Iterable<T> whereType<T>() => toIterable().whereType<T>();
 
   bool get isEmpty => length == 0;
@@ -904,6 +947,12 @@ extension NodeListExtension on NodeList {
   Iterable<Node> toIterable() => Iterable.generate(length, (i) => item(i)!);
 
   List<Node> toList() => List.generate(length, (i) => item(i)!);
+
+  VirtualListView<Node> get asListView =>
+      VirtualListView(() => length, (i) => item(i)!);
+
+  VirtualFixedListView<Node> get asListViewFixed =>
+      VirtualFixedListView(length, (i) => item(i)!);
 
   Iterable<Node> where(bool Function(Node element) test) =>
       toIterable().where(test);

--- a/lib/src/wev_utils_virtual_list.dart
+++ b/lib/src/wev_utils_virtual_list.dart
@@ -1,0 +1,86 @@
+import 'dart:collection';
+
+/// A read-only [List] view whose elements are computed lazily.
+///
+/// This list does not store elements internally. Instead, its length is
+/// provided by [size], and each element is produced on demand by [getter].
+///
+/// The value returned by [size] is queried every time [length] is accessed.
+/// If [size] returns different values over time, the list length may appear
+/// inconsistent during iteration.
+///
+/// All mutation operations are unsupported and will throw [UnsupportedError].
+class VirtualListView<E> extends ListBase<E> {
+  /// Returns the current number of elements in the list.
+  ///
+  /// This function is invoked every time [length] is accessed.
+  final int Function() size;
+
+  /// Returns the element at the given [index].
+  ///
+  /// The caller is responsible for ensuring that [index] is within bounds.
+  final E Function(int index) getter;
+
+  /// Creates a virtual, read-only list backed by [size] and [getter].
+  VirtualListView(this.size, this.getter);
+
+  /// The current length of the list, as returned by [size].
+  @override
+  int get length => size();
+
+  /// Returns the element at [index] using [getter].
+  @override
+  E operator [](int index) => getter(index);
+
+  /// Unsupported. This list is read-only.
+  @override
+  void operator []=(int index, E value) {
+    _throwUnmodifiable();
+  }
+
+  /// Unsupported. This list has a virtual, computed length.
+  @override
+  set length(int newLength) => _throwUnmodifiable();
+
+  Never _throwUnmodifiable() {
+    throw UnsupportedError("Unmodifiable `VirtualListView`");
+  }
+}
+
+/// A read-only [List] view with a fixed length and lazily computed elements.
+///
+/// Unlike [VirtualListView], the [length] of this list is fixed at construction
+/// time. Elements are produced on demand by [getter] and are not stored.
+///
+/// All mutation operations are unsupported and will throw [UnsupportedError].
+class VirtualFixedListView<E> extends ListBase<E> {
+  /// The fixed number of elements in the list.
+  @override
+  final int length;
+
+  /// Returns the element at the given [index].
+  ///
+  /// The caller is responsible for ensuring that [index] is within bounds.
+  final E Function(int index) getter;
+
+  /// Creates a virtual, read-only list with a fixed [length] and a [getter].
+  VirtualFixedListView(this.length, this.getter);
+
+  /// Returns the element at [index] using [getter].
+  @override
+  E operator [](int index) => getter(index);
+
+  /// Unsupported. This list is read-only.
+  @override
+  void operator []=(int index, E value) {
+    _throwUnmodifiable();
+  }
+
+  /// Unsupported. This list has a fixed length.
+  @override
+  set length(int newLength) => _throwUnmodifiable();
+
+  Never _throwUnmodifiable() {
+    throw UnsupportedError("Unmodifiable `VirtualFixedListView`");
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_utils
 description: A collection of useful Dart extensions for web development, enhancing JavaScript interop and simplifying common operations with the `web` package.
-version: 1.0.19
+version: 1.0.20
 repository: https://github.com/gmpassos/web_utils
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^5.1.1
-  test: ^1.28.0
+  test: ^1.29.0
   dependency_validator: ^5.0.3
 
 #dependency_overrides:

--- a/test/wev_utils_virtual_list_test.dart
+++ b/test/wev_utils_virtual_list_test.dart
@@ -1,0 +1,75 @@
+import 'package:test/test.dart';
+import 'package:web_utils/src/wev_utils_virtual_list.dart';
+
+void main() {
+  group('VirtualListView', () {
+    test('computes length lazily', () {
+      var sizeValue = 3;
+      final list = VirtualListView<int>(() => sizeValue, (i) => i * 10);
+
+      expect(list.length, 3);
+      sizeValue = 5;
+      expect(list.length, 5);
+    });
+
+    test('computes elements lazily via getter', () {
+      var calls = <int>[];
+      final list = VirtualListView<int>(() => 3, (i) {
+        calls.add(i);
+        return i + 1;
+      });
+
+      expect(list[0], 1);
+      expect(list[2], 3);
+      expect(calls, [0, 2]);
+    });
+
+    test('iterates using current length', () {
+      var sizeValue = 2;
+      final list = VirtualListView<int>(() => sizeValue, (i) => i);
+
+      expect(list.toList(), [0, 1]);
+
+      sizeValue = 4;
+      expect(list.toList(), [0, 1, 2, 3]);
+    });
+
+    test('mutation operations throw UnsupportedError', () {
+      final list = VirtualListView<int>(() => 1, (i) => i);
+
+      expect(() => list[0] = 10, throwsUnsupportedError);
+      expect(() => list.length = 10, throwsUnsupportedError);
+    });
+  });
+
+  group('VirtualFixedListView', () {
+    test('has fixed length', () {
+      final list = VirtualFixedListView<int>(3, (i) => i * 2);
+      expect(list.length, 3);
+    });
+
+    test('computes elements lazily via getter', () {
+      var calls = <int>[];
+      final list = VirtualFixedListView<int>(3, (i) {
+        calls.add(i);
+        return i + 5;
+      });
+
+      expect(list[1], 6);
+      expect(list[2], 7);
+      expect(calls, [1, 2]);
+    });
+
+    test('iterates correctly', () {
+      final list = VirtualFixedListView<int>(4, (i) => i);
+      expect(list.toList(), [0, 1, 2, 3]);
+    });
+
+    test('mutation operations throw UnsupportedError', () {
+      final list = VirtualFixedListView<int>(2, (i) => i);
+
+      expect(() => list[0] = 10, throwsUnsupportedError);
+      expect(() => list.length = 5, throwsUnsupportedError);
+    });
+  });
+}


### PR DESCRIPTION
- `HTMLOptionsCollection`, `TouchList`, `FileList`, `CSSRuleList`, `DOMTokenList`, `NamedNodeMap`, `HTMLCollection`, `NodeList` extensions:
  - Added `asListView` getter returning a `VirtualListView` for lazy indexed access.
  - Added `asListViewFixed` getter returning a `VirtualFixedListView` with fixed length.

- `pubspec.yaml`:
  - Updated `test` dependency from `^1.28.0` to `^1.29.0`.